### PR TITLE
Fix/continue button

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -269,7 +269,8 @@ class ChatViewSet(viewsets.ModelViewSet):
                     'id': str(chat.id),
                     'title': f"Chat with {chat.chatbot.name}",
                     'last_message': last_message_content,
-                    'character_name': bot.name if bot else "Unknown Bot"
+                    'character_name': bot.name if bot else "Unknown Bot",
+                    'character_id': str(bot.id)
                 })
                 print("Did")
             print(chat_list)


### PR DESCRIPTION
Fixed #5 
The continue chat button in the page ChatsHistoryPage didn't work because it didn't have the character's id, so modified the backend - views,py - to send that information.